### PR TITLE
Add oping

### DIFF
--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -24,6 +24,7 @@ RUN apk update && apk add --no-cache mtr \
  vim \
  kubectl \
  strace \
+ liboping \
  && rm -rf /var/cache/apk/*
 
 COPY files/.bashrc /root/.bashrc

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -22,6 +22,7 @@ RUN apt-get update && apt-get -y install traceroute \
     bind9-dnsutils \
     redis \
     vim \
+    oping \
     strace
 
 RUN curl -sS https://starship.rs/install.sh | sh -s -- -y


### PR DESCRIPTION
I'd like to propose to add `oping` to the list of installed packages, so that `noping` (*n*curses *oping*) is available. It is a nice little tool that can ping multiple hosts and display the result in a graphic format in the Terminal:

![image](https://github.com/donch/net-tools/assets/946488/4aae05d2-e2a3-43eb-9a27-5d4f7bdfdf48)

Would you mind adding it? 🙂 